### PR TITLE
Optional retry for ConnectionError and TimeoutErrror

### DIFF
--- a/rediscluster/pipeline.py
+++ b/rediscluster/pipeline.py
@@ -24,11 +24,12 @@ class StrictClusterPipeline(StrictRedisCluster):
     """
 
     def __init__(self, connection_pool, result_callbacks=None,
-                 response_callbacks=None, startup_nodes=None):
+                 response_callbacks=None, startup_nodes=None, retry_connection_error=True):
         """
         """
         self.command_stack = []
         self.refresh_table_asap = False
+        self.retry_connection_error = retry_connection_error
         self.connection_pool = connection_pool
         self.result_callbacks = result_callbacks or self.__class__.RESULT_CALLBACKS.copy()
         self.startup_nodes = startup_nodes if startup_nodes else []


### PR DESCRIPTION
**Current behavior:**
Currently, if a `ConnectionError` or a `TimeoutError` is raised, the default behavior is to retry the request `RedisClusterRequestTTL` times with a 100ms delay between each retry of the second half of the retries. e.g.: with  `RedisClusterRequestTTL` set to 16 (the current default), when a ConnectionError is raised, the request will be retried up to 16 times with the later 8 retries delayed by 100ms each.

**What this PR changes:**
This PR simply a `retry_connection_error` parameter to the client's `__init__` method. By default it is True, so the current behavior remains intact. Set it to False and the client will raise immediately on `ConnectionError` or a `TimeoutError`

**Rationale:**
While the current behavior is probably wanted/needed in some/most cases, it can be useful to have the `execute_command` method raise immediately on such errors. Say you're using Redis purely as a caching mechanism. The last thing you want is for a cache call to block, potentially up to 800ms, and topple your infra once requests build up at the door. This PR allows you to avoid that.